### PR TITLE
fix: Add missing requirements to run the notebooks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setup(
         "shap_e.rendering.blender",
         "shap_e.rendering.raycast",
         "shap_e.util",
+        "ipykernel",
+        "ipywidgets",
+        "pyyaml"
     ],
     install_requires=[
         "filelock",


### PR DESCRIPTION
This PR adds some missing requirements to run the provided jupyter-notebooks.